### PR TITLE
Animate evaluations, invalidWordLength, and tile filled

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,8 +19,6 @@ function App() {
     gameScreen,
     history,
     currentGuesses,
-    currentGuessWord,
-    currentGuessIndex,
     currentRoundIndex,
     prevScore,
     score,
@@ -38,9 +36,7 @@ function App() {
           gameSettings={gameSettings}
           score={score}
           currentRoundIndex={currentRoundIndex}
-          currentGuessWord={currentGuessWord}
           currentGuesses={currentGuesses}
-          currentGuessIndex={currentGuessIndex}
         />
       )}
       {gameScreen === 'roundScore' && (
@@ -49,11 +45,17 @@ function App() {
           isGameComplete={isGameComplete}
           prevScore={prevScore}
           newScore={score}
+          gameSettings={gameSettings}
           round={history[currentRoundIndex - 1]}
         />
       )}
       {gameScreen === 'gameScore' && (
-        <GameScoreScreen newGame={newGame} score={score} history={history} />
+        <GameScoreScreen
+          newGame={newGame}
+          score={score}
+          history={history}
+          gameSettings={gameSettings}
+        />
       )}
     </>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ function App() {
     addLetter,
     removeLetter,
     evaluateGuess,
+    endRound,
     nextRound,
   } = useGameState();
   const {
@@ -22,6 +23,7 @@ function App() {
     currentRoundIndex,
     prevScore,
     score,
+    isRoundComplete,
     isGameComplete,
   } = gameState;
   return (
@@ -33,7 +35,9 @@ function App() {
           evaluateGuess={evaluateGuess}
           addLetter={addLetter}
           removeLetter={removeLetter}
+          endRound={endRound}
           gameSettings={gameSettings}
+          isRoundComplete={isRoundComplete}
           score={score}
           currentRoundIndex={currentRoundIndex}
           currentGuesses={currentGuesses}

--- a/src/components/game/Board.tsx
+++ b/src/components/game/Board.tsx
@@ -19,24 +19,30 @@ const boardVariants = cva('flex flex-col justify-center', {
 type BoardProps = React.ComponentPropsWithoutRef<'div'> &
   VariantProps<typeof boardVariants> & {
     guesses: Guess[];
-    currentGuessIndex?: number;
+    guessesPerRound: number;
+    wordLength: number;
   };
 
 const Board = ({
   guesses,
+  guessesPerRound,
+  wordLength,
   size,
   className,
-  currentGuessIndex,
   ...props
 }: BoardProps) => {
+  const emptyRows: Guess[] = new Array<Guess>(
+    guessesPerRound - guesses.length,
+  ).fill([]);
   return (
     <div className={cn(boardVariants({ size }), className)} {...props}>
-      {guesses.map((guess, index) => (
+      {[...guesses, ...emptyRows].map((guess, index) => (
         <Row
           key={index}
           guess={guess}
+          wordLength={wordLength}
           size={size}
-          current={index === currentGuessIndex}
+          current={guesses.length === index + 1}
         />
       ))}
     </div>

--- a/src/components/game/Board.tsx
+++ b/src/components/game/Board.tsx
@@ -19,13 +19,25 @@ const boardVariants = cva('flex flex-col justify-center', {
 type BoardProps = React.ComponentPropsWithoutRef<'div'> &
   VariantProps<typeof boardVariants> & {
     guesses: Guess[];
+    currentGuessIndex?: number;
   };
 
-const Board = ({ guesses, size, className }: BoardProps) => {
+const Board = ({
+  guesses,
+  size,
+  className,
+  currentGuessIndex,
+  ...props
+}: BoardProps) => {
   return (
-    <div className={cn(boardVariants({ size }), className)}>
+    <div className={cn(boardVariants({ size }), className)} {...props}>
       {guesses.map((guess, index) => (
-        <Row key={index} guess={guess} size={size} />
+        <Row
+          key={index}
+          guess={guess}
+          size={size}
+          current={index === currentGuessIndex}
+        />
       ))}
     </div>
   );

--- a/src/components/game/Keyboard.tsx
+++ b/src/components/game/Keyboard.tsx
@@ -7,20 +7,11 @@ const middleRow = ['a', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l'];
 const bottomRow = ['z', 'x', 'c', 'v', 'b', 'n', 'm'];
 
 type KeyboardProps = {
-  addLetter: (letter: string) => void;
-  removeLetter: () => void;
-  evaluateGuess: (word: string) => void;
-  currentGuessWord: string;
+  parseKey: (e: KeyboardEvent | { key: string }) => void;
   currentGuesses: Guess[];
 };
 
-const Keyboard = ({
-  addLetter,
-  removeLetter,
-  evaluateGuess,
-  currentGuessWord,
-  currentGuesses,
-}: KeyboardProps) => {
+const Keyboard = ({ parseKey, currentGuesses }: KeyboardProps) => {
   const evaluationRanking = ['unevaluated', 'absent', 'present', 'correct'];
   const letterEvaluationLookup = 'abcdefghijklmnopqrstuvwxyz'
     .split('')
@@ -53,7 +44,7 @@ const Keyboard = ({
           <Key
             key={letter}
             evaluation={getEvaluation(letter)}
-            onClick={() => addLetter(letter)}
+            onClick={() => parseKey({ key: letter })}
           >
             {letter}
           </Key>
@@ -65,7 +56,7 @@ const Keyboard = ({
           <Key
             key={letter}
             evaluation={getEvaluation(letter)}
-            onClick={() => addLetter(letter)}
+            onClick={() => parseKey({ key: letter })}
           >
             {letter}
           </Key>
@@ -75,7 +66,7 @@ const Keyboard = ({
       <div className={rowStyle}>
         <Key
           className="w-14 sm:w-20"
-          onClick={() => evaluateGuess(currentGuessWord)}
+          onClick={() => parseKey({ key: 'Enter' })}
         >
           <CornerDownLeft /> {/*Enter*/}
         </Key>
@@ -83,12 +74,15 @@ const Keyboard = ({
           <Key
             key={letter}
             evaluation={getEvaluation(letter)}
-            onClick={() => addLetter(letter)}
+            onClick={() => parseKey({ key: letter })}
           >
             {letter}
           </Key>
         ))}
-        <Key className="w-14 sm:w-20" onClick={removeLetter}>
+        <Key
+          className="w-14 sm:w-20"
+          onClick={() => parseKey({ key: 'Backspace' })}
+        >
           <Delete />
         </Key>
       </div>

--- a/src/components/game/Row.tsx
+++ b/src/components/game/Row.tsx
@@ -11,6 +11,9 @@ const rowVariants = cva('mx-auto flex', {
       small: 'board-gap-small',
       tiny: 'board-gap-tiny',
     },
+    current: {
+      true: 'current',
+    },
   },
   defaultVariants: {
     size: 'big',
@@ -21,9 +24,9 @@ type RowProps = React.ComponentPropsWithoutRef<'div'> &
     guess: Guess;
   };
 
-const Row = ({ guess, className, size }: RowProps) => {
+const Row = ({ guess, className, size, current }: RowProps) => {
   return (
-    <div className={cn(rowVariants({ size }), className)}>
+    <div className={cn(rowVariants({ size, current }), className)}>
       {guess.map(({ letter, evaluation }, index) => (
         <Tile key={index} letter={letter} evaluation={evaluation} size={size} />
       ))}

--- a/src/components/game/Row.tsx
+++ b/src/components/game/Row.tsx
@@ -28,7 +28,13 @@ const Row = ({ guess, className, size, current }: RowProps) => {
   return (
     <div className={cn(rowVariants({ size, current }), className)}>
       {guess.map(({ letter, evaluation }, index) => (
-        <Tile key={index} letter={letter} evaluation={evaluation} size={size} />
+        <Tile
+          key={index}
+          letter={letter}
+          evaluation={evaluation}
+          size={size}
+          style={{ '--order': `${index}` } as React.CSSProperties}
+        />
       ))}
     </div>
   );

--- a/src/components/game/Row.tsx
+++ b/src/components/game/Row.tsx
@@ -8,7 +8,7 @@ import {
 } from '@/domain/game';
 import { cn } from '@/utils/cn';
 
-const rowVariants = cva('mx-auto flex', {
+const rowVariants = cva('row mx-auto flex', {
   variants: {
     size: {
       big: 'board-gap-big',

--- a/src/components/game/Row.tsx
+++ b/src/components/game/Row.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { Tile } from '@/components/game/Tile';
-import { Guess } from '@/domain/game';
+import {
+  DefaultLetterEvaluation,
+  type Guess,
+  type LetterEvaluation,
+} from '@/domain/game';
 import { cn } from '@/utils/cn';
 
 const rowVariants = cva('mx-auto flex', {
@@ -22,12 +26,16 @@ const rowVariants = cva('mx-auto flex', {
 type RowProps = React.ComponentPropsWithoutRef<'div'> &
   VariantProps<typeof rowVariants> & {
     guess: Guess;
+    wordLength: number;
   };
 
-const Row = ({ guess, className, size, current }: RowProps) => {
+const Row = ({ guess, className, size, current, wordLength }: RowProps) => {
+  const emptyTiles: Guess = new Array<LetterEvaluation>(
+    wordLength - guess.length,
+  ).fill(new DefaultLetterEvaluation());
   return (
     <div className={cn(rowVariants({ size, current }), className)}>
-      {guess.map(({ letter, evaluation }, index) => (
+      {[...guess, ...emptyTiles].map(({ letter, evaluation }, index) => (
         <Tile
           key={index}
           letter={letter}

--- a/src/components/game/Tile.tsx
+++ b/src/components/game/Tile.tsx
@@ -31,7 +31,9 @@ type TileProps = React.ComponentPropsWithoutRef<'div'> &
 
 const Tile = ({ letter, evaluation, size }: TileProps) => {
   return (
-    <div className={cn(tileVariants({ evaluation, size }))}>
+    <div
+      className={cn(tileVariants({ evaluation, size }), { unfilled: !letter })}
+    >
       {size === 'tiny' ? '' : letter}
     </div>
   );

--- a/src/components/game/Tile.tsx
+++ b/src/components/game/Tile.tsx
@@ -6,9 +6,9 @@ import { cn } from '@/utils/cn';
 const tileVariants = cva('flex items-center justify-center', {
   variants: {
     evaluation: {
-      correct: 'evaluation-correct',
-      present: 'evaluation-present',
-      absent: 'evaluation-absent',
+      correct: 'evaluated evaluation-correct',
+      present: 'evaluated evaluation-present',
+      absent: 'evaluated evaluation-absent',
       unevaluated: 'evaluation-unevaluated',
     },
     size: {
@@ -29,14 +29,16 @@ type TileProps = React.ComponentPropsWithoutRef<'div'> &
   VariantProps<typeof tileVariants> &
   LetterEvaluation;
 
-const Tile = ({ letter, evaluation, size }: TileProps) => {
+const Tile = ({ letter, evaluation, size, className, ...props }: TileProps) => {
   return (
     <div
       className={cn(
         tileVariants({ evaluation, size }),
         { filled: letter },
         { unfilled: !letter },
+        className,
       )}
+      {...props}
     >
       {size === 'tiny' ? '' : letter}
     </div>

--- a/src/components/game/Tile.tsx
+++ b/src/components/game/Tile.tsx
@@ -32,7 +32,11 @@ type TileProps = React.ComponentPropsWithoutRef<'div'> &
 const Tile = ({ letter, evaluation, size }: TileProps) => {
   return (
     <div
-      className={cn(tileVariants({ evaluation, size }), { unfilled: !letter })}
+      className={cn(
+        tileVariants({ evaluation, size }),
+        { filled: letter },
+        { unfilled: !letter },
+      )}
     >
       {size === 'tiny' ? '' : letter}
     </div>

--- a/src/domain/game.ts
+++ b/src/domain/game.ts
@@ -37,6 +37,7 @@ type GameState = {
   roundScore: number;
   prevScore: number;
   score: number;
+  isRoundComplete: boolean;
   isGameComplete: boolean;
 };
 
@@ -56,6 +57,7 @@ const initialGameState: GameState = {
   roundScore: 0,
   prevScore: 0,
   score: 0,
+  isRoundComplete: false,
   isGameComplete: false,
 };
 

--- a/src/domain/game.ts
+++ b/src/domain/game.ts
@@ -33,8 +33,6 @@ type GameState = {
   currentWord: string;
   history: Round[];
   currentGuesses: Guess[];
-  currentGuessWord: string;
-  currentGuessIndex: number;
   currentRoundIndex: number;
   roundScore: number;
   prevScore: number;
@@ -54,8 +52,6 @@ const initialGameState: GameState = {
   currentWord: '',
   history: [],
   currentGuesses: [],
-  currentGuessWord: '',
-  currentGuessIndex: 0,
   currentRoundIndex: 0,
   roundScore: 0,
   prevScore: 0,

--- a/src/index.css
+++ b/src/index.css
@@ -53,35 +53,59 @@
   }
 
   /* common styles for evaluation */
-  .evaluation-correct {
-    text-shadow: 0 1px 2px rgb(21 128 61 / var(--tw-bg-opacity));
-    @apply bg-green-500 text-white;
+
+  .evaluation-unevaluated {
+    text-shadow: var(--ev-unevaluated-text-shadow);
+    background-color: var(--ev-unevaluated-bg-color);
+    color: var(--ev-unevaluated-text-color);
     &.btn {
+      @apply transition-colors hover:bg-slate-300/90 active:bg-slate-400;
+    }
+  }
+  .evaluation-correct {
+    --ev-text-shadow: var(--ev-correct-text-shadow);
+    --ev-bg-color: var(--ev-correct-bg-color);
+    --ev-text-color: var(--ev-correct-text-color);
+    &.btn {
+      text-shadow: var(--ev-correct-text-shadow);
+      background-color: var(--ev-correct-bg-color);
+      color: var(--ev-correct-text-color);
       @apply transition-colors hover:bg-green-500/90 active:bg-green-600;
     }
   }
 
   .evaluation-present {
-    text-shadow: 0 1px 2px rgb(161 98 7 / var(--tw-bg-opacity));
-    @apply bg-yellow-500 text-white;
+    --ev-text-shadow: var(--ev-present-text-shadow);
+    --ev-bg-color: var(--ev-present-bg-color);
+    --ev-text-color: var(--ev-present-text-color);
     &.btn {
+      text-shadow: var(--ev-present-text-shadow);
+      background-color: var(--ev-present-bg-color);
+      color: var(--ev-present-text-color);
       @apply transition-colors hover:bg-yellow-500/90 active:bg-yellow-600;
     }
   }
 
   .evaluation-absent {
-    text-shadow: 0 1px 2px rgb(51 65 85 / var(--tw-bg-opacity));
-    @apply bg-slate-500 text-white;
+    --ev-text-shadow: var(--ev-absent-text-shadow);
+    --ev-bg-color: var(--ev-absent-bg-color);
+    --ev-text-color: var(--ev-absent-text-color);
     &.btn {
+      text-shadow: var(--ev-absent-text-shadow);
+      background-color: var(--ev-absent-bg-color);
+      color: var(--ev-absent-text-color);
       @apply transition-colors hover:bg-slate-500/90 active:bg-slate-600;
     }
   }
-
-  .evaluation-unevaluated {
-    @apply bg-slate-300 text-black;
-    &.btn {
-      @apply transition-colors hover:bg-slate-300/90 active:bg-slate-400;
-    }
+  .evaluated {
+    text-shadow: var(--ev-text-shadow);
+    background-color: var(--ev-bg-color);
+    color: var(--ev-text-color);
+  }
+  .animate-evaluation .evaluated {
+    animation: revealEvaluation 0.5s;
+    animation-delay: calc(var(--order) * 0.1s);
+    animation-fill-mode: both;
   }
 
   .current .filled {
@@ -124,6 +148,33 @@
     }
     to {
       transform: translateY(5px);
+    }
+  }
+
+  @keyframes revealEvaluation {
+    0% {
+      transform: rotateY(0);
+      text-shadow: var(--ev-unevaluated-text-shadow);
+      background-color: var(--ev-unevaluated-bg-color);
+      color: var(--ev-unevaluated-text-color);
+    }
+    45% {
+      transform: rotateY(90deg);
+      text-shadow: var(--ev-unevaluated-text-shadow);
+      background-color: var(--ev-unevaluated-bg-color);
+      color: var(--ev-unevaluated-text-color);
+    }
+    55% {
+      transform: rotateY(90deg);
+      text-shadow: var(--ev-text-shadow);
+      background-color: var(--ev-bg-color);
+      color: var(--ev-text-color);
+    }
+    100% {
+      transform: rotateY(0);
+      text-shadow: var(--ev-text-shadow);
+      background-color: var(--ev-bg-color);
+      color: var(--ev-text-color);
     }
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -83,4 +83,34 @@
       @apply transition-colors hover:bg-slate-300/90 active:bg-slate-400;
     }
   }
+
+  .shake-unfilled .current .unfilled {
+    animation: headShake 0.5s ease-in-out;
+  }
+
+  @keyframes headShake {
+    0% {
+      transform: translateX(0);
+    }
+
+    6.5% {
+      transform: translateX(-6px) rotateY(-9deg);
+    }
+
+    18.5% {
+      transform: translateX(5px) rotateY(7deg);
+    }
+
+    31.5% {
+      transform: translateX(-3px) rotateY(-5deg);
+    }
+
+    43.5% {
+      transform: translateX(2px) rotateY(3deg);
+    }
+
+    50% {
+      transform: translateX(0);
+    }
+  }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -102,13 +102,13 @@
     background-color: var(--ev-bg-color);
     color: var(--ev-text-color);
   }
-  .animate-evaluation .evaluated {
+  .animate .evaluated {
     animation: revealEvaluation 0.5s;
     animation-delay: calc(var(--order) * 0.1s);
     animation-fill-mode: both;
   }
 
-  .current .filled {
+  .animate .current .filled {
     animation: dip 0.1s;
   }
 

--- a/src/index.css
+++ b/src/index.css
@@ -102,7 +102,9 @@
     background-color: var(--ev-bg-color);
     color: var(--ev-text-color);
   }
-  .animate .evaluated {
+  /* the specificity of the evaluated animation must remain higher than the filled animation */
+  /* it works, but it is very brittle */
+  .animate .row div.evaluated {
     animation: revealEvaluation 0.5s;
     animation-delay: calc(var(--order) * 0.1s);
     animation-fill-mode: both;

--- a/src/index.css
+++ b/src/index.css
@@ -84,6 +84,10 @@
     }
   }
 
+  .current .filled {
+    animation: dip 0.1s;
+  }
+
   .shake-unfilled .current .unfilled {
     animation: headShake 0.5s ease-in-out;
   }
@@ -111,6 +115,15 @@
 
     50% {
       transform: translateX(0);
+    }
+  }
+
+  @keyframes dip {
+    from {
+      transform: translateY(0);
+    }
+    to {
+      transform: translateY(5px);
     }
   }
 }

--- a/src/screens/BoardScreen.tsx
+++ b/src/screens/BoardScreen.tsx
@@ -97,7 +97,9 @@ const BoardScreen = ({
         )}
         currentGuessIndex={currentGuessIndex}
         onAnimationEnd={handleAnimationEnd}
-        className={cn('mb-3', { 'shake-unfilled': animateInvalidGuessLength })}
+        className={cn('animate-evaluation mb-3', {
+          'shake-unfilled': animateInvalidGuessLength,
+        })}
       />
       <div className="flex flex-1 items-end justify-center">
         <Keyboard parseKey={parseKey} currentGuesses={currentGuesses} />

--- a/src/screens/BoardScreen.tsx
+++ b/src/screens/BoardScreen.tsx
@@ -88,7 +88,7 @@ const BoardScreen = ({
         guessesPerRound={guessesPerRound}
         wordLength={wordLength}
         onAnimationEnd={handleAnimationEnd}
-        className={cn('animate-evaluation mb-3', {
+        className={cn('animate mb-3', {
           'shake-unfilled': animateInvalidGuessLength,
         })}
       />

--- a/src/screens/BoardScreen.tsx
+++ b/src/screens/BoardScreen.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { debounce } from 'lodash-es';
 import { Board } from '@/components/game/Board';
 import { GameStatusToolbar } from '@/components/game/GameStatusToolbar';
 import { Keyboard } from '@/components/game/Keyboard';
@@ -9,7 +10,9 @@ type BoardScreenProps = React.ComponentPropsWithoutRef<'div'> & {
   evaluateGuess: () => void;
   addLetter: (letter: string) => void;
   removeLetter: () => void;
+  endRound: () => void;
   gameSettings: GameSettings;
+  isRoundComplete: boolean;
   score: number;
   currentRoundIndex: number;
   currentGuesses: Guess[];
@@ -19,7 +22,9 @@ const BoardScreen = ({
   evaluateGuess,
   addLetter,
   removeLetter,
+  endRound,
   gameSettings,
+  isRoundComplete,
   score,
   currentRoundIndex,
   currentGuesses,
@@ -27,11 +32,18 @@ const BoardScreen = ({
   const [animateInvalidGuessLength, setAnimateInvalidGuessLength] =
     React.useState(false);
 
+  // debounced because it's called by the revealEvaluation animation ending
+  //   and that event fires 5 times in a row
+  const debouncedEndRound = debounce(() => {
+    endRound();
+  }, 200);
   const currentGuess = currentGuesses[currentGuesses.length - 1];
 
   const handleAnimationEnd = (e: React.AnimationEvent<HTMLDivElement>) => {
     if (e.animationName === 'headShake') {
       setAnimateInvalidGuessLength(false);
+    } else if (isRoundComplete && e.animationName === 'revealEvaluation') {
+      debouncedEndRound();
     }
   };
 

--- a/src/screens/GameScoreScreen.tsx
+++ b/src/screens/GameScoreScreen.tsx
@@ -3,14 +3,24 @@ import { Board } from '@/components/game/Board';
 import { Divider } from '@/components/layout/Divider';
 import { Button } from '@/components/ui/Button';
 import { MedalIcon } from '@/components/ui/MedalIcon';
-import { defaultGameSettings, GameSettings, Round } from '@/domain/game';
+import {
+  defaultGameSettings,
+  type GameSettings,
+  type Round,
+} from '@/domain/game';
 
 type GameScoreScreenProps = {
   newGame: (gameSettings: GameSettings) => void;
   score: number;
   history: Round[];
+  gameSettings: GameSettings;
 };
-const GameScoreScreen = ({ newGame, score, history }: GameScoreScreenProps) => {
+const GameScoreScreen = ({
+  newGame,
+  score,
+  history,
+  gameSettings,
+}: GameScoreScreenProps) => {
   //set up autofocus delay for button
   const buttonRef = React.useRef<HTMLButtonElement>(null);
   React.useEffect(() => {
@@ -40,6 +50,8 @@ const GameScoreScreen = ({ newGame, score, history }: GameScoreScreenProps) => {
           <div className="flex w-full items-center justify-around" key={index}>
             <Board
               guesses={round.guesses}
+              guessesPerRound={gameSettings.guessesPerRound}
+              wordLength={gameSettings.wordLength}
               size="tiny"
               className="flex-none rounded bg-secondary p-1"
             />

--- a/src/screens/RoundScoreScreen.tsx
+++ b/src/screens/RoundScoreScreen.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/Button';
 import { HeartCrackIcon } from '@/components/ui/HeartCrackIcon';
 import { TargetIcon } from '@/components/ui/TargetIcon';
 import { TrophyIcon } from '@/components/ui/TrophyIcon';
-import { type Round } from '@/domain/game';
+import { type GameSettings, type Round } from '@/domain/game';
 import { cn } from '@/utils/cn';
 import {
   checkGuessComplete,
@@ -20,6 +20,7 @@ type RoundScoreScreenProps = {
   prevScore: number;
   newScore: number;
   round: Round;
+  gameSettings: GameSettings;
 };
 const RoundScoreScreen = ({
   nextRound,
@@ -27,6 +28,7 @@ const RoundScoreScreen = ({
   prevScore,
   newScore,
   round,
+  gameSettings,
 }: RoundScoreScreenProps) => {
   //set up autofocus delay for button
   const buttonRef = React.useRef<HTMLButtonElement>(null);
@@ -62,6 +64,7 @@ const RoundScoreScreen = ({
             word,
             wasGuessCorrect ? 'correct' : 'unevaluated',
           )}
+          wordLength={gameSettings.wordLength}
         />
       </div>
       <Divider thickness="thick" />
@@ -72,6 +75,8 @@ const RoundScoreScreen = ({
         <Board
           guesses={guesses}
           size={'small'}
+          wordLength={gameSettings.wordLength}
+          guessesPerRound={gameSettings.guessesPerRound}
           className="mb-2 flex-none rounded-md bg-secondary p-2 sm:mb-0 sm:p-3"
         />
         <div className="flex flex-col items-center justify-center">

--- a/src/styles/shadcn-green-theme.css
+++ b/src/styles/shadcn-green-theme.css
@@ -21,6 +21,23 @@
     --ring: 142.1 76.2% 36.3%;
     --radius: 0.75rem;
 
+    /* evaluation styles */
+    --ev-unevaluated-text-shadow: inherit;
+    --ev-unevaluated-bg-color: theme(colors.slate.300);
+    --ev-unevaluated-text-color: theme(colors.black);
+
+    --ev-correct-text-shadow: 0 1px 2px theme(colors.green.700);
+    --ev-correct-bg-color: theme(colors.green.500);
+    --ev-correct-text-color: theme(colors.white);
+
+    --ev-present-text-shadow: 0 1px 2px theme(colors.yellow.700);
+    --ev-present-bg-color: theme(colors.yellow.500);
+    --ev-present-text-color: theme(colors.white);
+
+    --ev-absent-text-shadow: 0 1px 2px theme(colors.slate.700);
+    --ev-absent-bg-color: theme(colors.slate.500);
+    --ev-absent-text-color: theme(colors.white);
+
     --fooCard: hsl(0 0% 100%);
     --fooCardFG: hsl(240 10% 3.9%);
 


### PR DESCRIPTION
Added animations for some key events:
- when guess is evaluated, flip over each tile (staggered)
- when entering letters into the current guess, animate the tile being filled
- when trying to enter a guess which is too short, animate the unfilled tiles shaking

Also refactored the game state logic to no longer end the round during the `evaluateGuess()` action, instead make `endRound()` it's own action `BoardScreen` calls when the `revealEvaluation` animation complete
 - this prevents the transition to `RoundScoreScreen` happening before the final evaluation animation finishes

As part of the game state logic refactor, I also changed how `currentGuesses` works and how `Board` and `Row` component handle guesses:
- instead of `currentGuesses` being filled with unevaluated guesses and using `currentGuessIndex` to keep track of the current guess, `currentGuesses` now only contains the current guesses, and the last guess in the array is the current guess
  - the current guess contains no "empty" letter evaluations
- `currentGuessWord` was removed in favor of just pushing letters directly into the current guess
  - `BoardScreen` no longer creates a guess from the `currentGuessWord` and splices it into the guesses array handed to the `Board` component - now it just passes the `currentGuesses` with no modification required
  - `addLetter()` and `removeLetter()` actions manipulate the current guess instead of the `currentGuessWord`
